### PR TITLE
Feat: 新增功能-穿比較套按鈕

### DIFF
--- a/data/changeLog.json
+++ b/data/changeLog.json
@@ -1,5 +1,11 @@
 [
     {
+        "date": "2026-06-20",
+        "changes": [
+            "新增功能「穿比較套」，特別感謝 <a href=\"https://github.com/Neillife\" target=\"_blank\">雪胖</a> 對本項目做出的貢獻。"
+        ]
+    },
+    {
         "date": "2026-06-18",
         "changes": [
             "新增「真我假面」套裝，先暫用中文名稱",

--- a/index.html
+++ b/index.html
@@ -310,6 +310,119 @@
 
     <div
       class="modal fade"
+      id="compareBuildConfirmModal"
+      tabindex="-1"
+      aria-labelledby="compareBuildConfirmModalLabel"
+      aria-hidden="true"
+    >
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="compareBuildConfirmModalLabel">檢視比較</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+              aria-label="Close"
+            ></button>
+          </div>
+          <div class="modal-body">
+            先前設定的比較套選擇部位如下
+            <div class="equipment-selection">
+              <div class="equipment-parts" id="equipmentPartss">
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="weapon-compare"
+                >
+                  武器
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="accessoryWeapon-compare"
+                >
+                  飾品(武器)
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="support-compare"
+                >
+                  支援
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="faceTop-compare"
+                >
+                  臉上
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="accessoryUpper-compare"
+                >
+                  飾品(上衣)
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="faceMiddle-compare"
+                >
+                  臉中
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="accessoryLower-compare"
+                >
+                  飾品(下衣)
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="faceBottom-compare"
+                >
+                  臉下
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="arm-compare"
+                >
+                  手臂
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="earring-compare"
+                >
+                  耳環
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="necklace-compare"
+                >
+                  項鍊
+                </div>
+                <div
+                  class="equipment-part normalCursorArea"
+                  id="ring-compare"
+                >
+                  戒指
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button
+              type="button"
+              class="btn btn-secondary"
+              data-bs-dismiss="modal"
+            >
+              關閉
+            </button>
+            <button type="button" class="btn btn-danger" onclick="processCompareBuild()">
+              穿比較套
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div
+      class="modal fade"
       id="resetConfirmModal"
       tabindex="-1"
       aria-labelledby="resetConfirmModalLabel"

--- a/src/els.js
+++ b/src/els.js
@@ -18,6 +18,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const suitEffectsSection = document.getElementById("suitEffectsSection");
     const comparisonControls = document.getElementById("saveForCompareBtn");
     const clearCompareBtn = document.getElementById("clearCompareBtn");
+    const setupCompareBuildBtn = document.getElementById("setupCompareBuildBtn");
     const comparisonHeader = document.getElementById("comparisonHeader");
     const comparisonCells = document.querySelectorAll("td[data-comparison]");
 
@@ -45,6 +46,11 @@ document.addEventListener("DOMContentLoaded", async () => {
         }
         if (clearCompareBtn) {
             clearCompareBtn.style.display = toggleSections.checked
+                ? "none"
+                : (Object.keys(savedAttributes).length > 0 ? "inline-block" : "none");
+        }
+        if (setupCompareBuildBtn) {
+            setupCompareBuildBtn.style.display = toggleSections.checked
                 ? "none"
                 : (Object.keys(savedAttributes).length > 0 ? "inline-block" : "none");
         }
@@ -136,6 +142,10 @@ let allEquipmentData = [];
 let searchQuery = '';
 let filteredData = [];
 let savedAttributes = {};
+let selectedAttributesOrigin = {};
+let selectedAttributesBackup = {};
+let suitEffectsCheckBoxStatusOrigin = [];
+let suitEffectsCheckBoxStatusBackup = [];
 
 
 const attributeList = [
@@ -360,8 +370,16 @@ function addCompareButton() {
         clearButton.onclick = clearComparison;
         clearButton.style.display = "none";
 
+        const buildButton = document.createElement("button");
+        buildButton.id = "setupCompareBuildBtn";
+        buildButton.className = "btn btn-outline-primary btn-sm ms-1 me-1";
+        buildButton.innerHTML = "穿比較套";
+        buildButton.onclick = processCompareBuild;
+        buildButton.style.display = "none";
+
         btnGroup.appendChild(saveButton);
         btnGroup.appendChild(clearButton);
+        btnGroup.appendChild(buildButton);
         buttonContainer.appendChild(btnGroup);
 
         finalValuesHeader.parentNode.replaceChild(buttonContainer, finalValuesHeader);
@@ -378,9 +396,98 @@ function clearComparison() {
     document.querySelectorAll(".comparison-indicator").forEach(el => el.remove());
     document.getElementById("saveForCompareBtn").innerHTML = "新增比較";
     document.getElementById("clearCompareBtn").style.display = "none";
+
+    selectedAttributesOrigin = {};
+    selectedAttributesBackup = {};
+    suitEffectsCheckBoxStatusOrigin = [];
+    suitEffectsCheckBoxStatusBackup = [];
+    document.getElementById("setupCompareBuildBtn").innerHTML = "穿比較套";
+    document.getElementById("setupCompareBuildBtn").className = "btn btn-outline-primary btn-sm ms-1 me-1";
+    document.getElementById("setupCompareBuildBtn").style.display = "none";
+}
+
+function setupBuild(selectedBuildList, suitEffectsCheckBoxStatus) {
+    let partTypes = [
+        "weapon", 
+        "accessoryWeapon", 
+        "support", 
+        "faceTop", 
+        "faceMiddle", 
+        "faceBottom", 
+        "necklace", 
+        "accessoryUpper", 
+        "accessoryLower", 
+        "arm", 
+        "earring", 
+        "ring"
+    ];
+
+    for (let i in partTypes) {
+        if (selectedBuildList[partTypes[i]] !== undefined) {
+            updateSelectedPart(partTypes[i], selectedBuildList[partTypes[i]]?.name, selectedBuildList[partTypes[i]]?.attributes?.id, selectedBuildList[partTypes[i]]?.setName);
+        } else {
+            clearSelectedPart(partTypes[i]);
+        }
+    }
+
+    suitEffectsList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+        let isMatch = suitEffectsCheckBoxStatus.some(item => checkbox.id.startsWith(item));
+        if (isMatch) {
+            checkbox.checked = true;
+        } else {
+            checkbox.checked = false;
+        }
+    });
+}
+
+function saveSelectedBuildData(selectedBuildList, suitEffectsCheckBoxStatus) {
+    const suitEffectsList = document.getElementById("suitEffectsList");
+
+    for (let key in selectedBuildList) {
+        delete selectedBuildList[key];
+    }
+
+    Object.assign(selectedBuildList, structuredClone(selectedAttributes));
+    suitEffectsCheckBoxStatus.length = 0;
+
+    suitEffectsList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+        if (checkbox.checked) {
+            suitEffectsCheckBoxStatus.push(checkbox.id.split('-')[0]);
+        }
+    });
+}
+
+function processCompareBuild() {
+    if (this.classList.contains('btn-outline-primary')) {
+        this.classList.remove('btn-outline-primary');
+        this.classList.add('btn-warning');
+        this.innerHTML = "穿原本套";
+
+        // 穿上之前先記錄目前選擇的所有冰裝與套裝效果再穿上
+        saveSelectedBuildData(selectedAttributesOrigin, suitEffectsCheckBoxStatusOrigin);
+
+        // 開始穿上
+        setupBuild(selectedAttributesBackup, suitEffectsCheckBoxStatusBackup);
+    } else {
+        this.classList.remove('btn-warning');
+        this.classList.add('btn-outline-primary');
+        this.innerHTML = "穿比較套";
+
+        // 穿回的時候用穿上之前紀錄的狀態
+        setupBuild(selectedAttributesOrigin, suitEffectsCheckBoxStatusOrigin);
+    }
+
+    // 重新處理畫面渲染和數值計算
+    updateFinalValues();
+    removeZeroCountSuits();
+    applySuitEffectClasses();
+    updateComparisonDisplay();
 }
 
 function saveCurrentValues() {
+    // 紀錄目前選擇的所有冰裝與原本的套裝效果
+    saveSelectedBuildData(selectedAttributesBackup, suitEffectsCheckBoxStatusBackup);
+
     savedAttributes = {};
     const attributeCells = document.querySelectorAll("td[data-attribute]");
 
@@ -398,6 +505,7 @@ function saveCurrentValues() {
     updateComparisonDisplay();
 
     document.getElementById("clearCompareBtn").style.display = "inline-block";
+    document.getElementById("setupCompareBuildBtn").style.display = "inline-block";
     document.getElementById("saveForCompareBtn").innerHTML = "更新比較";
 }
 

--- a/src/els.js
+++ b/src/els.js
@@ -101,6 +101,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     resetConfirmModal = new bootstrap.Modal(document.getElementById('resetConfirmModal'));
+    compareBuildConfirmModal = new bootstrap.Modal(document.getElementById('compareBuildConfirmModal'));
 
     updateFilteredData();
     displayAvailableIceEquipment();
@@ -142,9 +143,7 @@ let allEquipmentData = [];
 let searchQuery = '';
 let filteredData = [];
 let savedAttributes = {};
-let selectedAttributesOrigin = {};
 let selectedAttributesBackup = {};
-let suitEffectsCheckBoxStatusOrigin = [];
 let suitEffectsCheckBoxStatusBackup = [];
 
 
@@ -373,8 +372,8 @@ function addCompareButton() {
         const buildButton = document.createElement("button");
         buildButton.id = "setupCompareBuildBtn";
         buildButton.className = "btn btn-outline-primary btn-sm ms-1 me-1";
-        buildButton.innerHTML = "穿比較套";
-        buildButton.onclick = processCompareBuild;
+        buildButton.innerHTML = "檢視比較";
+        buildButton.onclick = showCompareBuildConfirmModal;
         buildButton.style.display = "none";
 
         btnGroup.appendChild(saveButton);
@@ -397,16 +396,12 @@ function clearComparison() {
     document.getElementById("saveForCompareBtn").innerHTML = "新增比較";
     document.getElementById("clearCompareBtn").style.display = "none";
 
-    selectedAttributesOrigin = {};
     selectedAttributesBackup = {};
-    suitEffectsCheckBoxStatusOrigin = [];
     suitEffectsCheckBoxStatusBackup = [];
-    document.getElementById("setupCompareBuildBtn").innerHTML = "穿比較套";
-    document.getElementById("setupCompareBuildBtn").className = "btn btn-outline-primary btn-sm ms-1 me-1";
     document.getElementById("setupCompareBuildBtn").style.display = "none";
 }
 
-function setupBuild(selectedBuildList, suitEffectsCheckBoxStatus) {
+function processSelectedComparePart(selectedBuildList, isSetupBuild) {
     let partTypes = [
         "weapon", 
         "accessoryWeapon", 
@@ -424,12 +419,57 @@ function setupBuild(selectedBuildList, suitEffectsCheckBoxStatus) {
 
     for (let i in partTypes) {
         if (selectedBuildList[partTypes[i]] !== undefined) {
-            updateSelectedPart(partTypes[i], selectedBuildList[partTypes[i]]?.name, selectedBuildList[partTypes[i]]?.attributes?.id, selectedBuildList[partTypes[i]]?.setName);
+            if (isSetupBuild) {
+                updateSelectedPart(partTypes[i], selectedBuildList[partTypes[i]]?.name, selectedBuildList[partTypes[i]]?.attributes?.id, selectedBuildList[partTypes[i]]?.setName);
+            } else {
+                let targetCell = document.getElementById(`${partTypes[i]}-compare`);
+                if (targetCell) {
+                    targetCell.innerHTML = `<span class="part-name">${getPartName(
+                        partTypes[i]
+                    )}<br>${selectedBuildList[partTypes[i]]?.setName}</span>`;
+                    targetCell.classList.add("selected-part");
+                }
+            }
         } else {
-            clearSelectedPart(partTypes[i]);
+            if (isSetupBuild) {
+                clearSelectedPart(partTypes[i]);
+            } else {
+                let targetCell = document.getElementById(`${partTypes[i]}-compare`);
+                if (targetCell) {
+                    targetCell.innerHTML = `<span class="part-name">${getPartName(
+                        partTypes[i]
+                    )}</span>`;
+                    targetCell.classList.remove("selected-part");
+                }
+            }
         }
     }
 
+    if (!isSetupBuild) {
+        document.querySelectorAll('.equipment-part.normalCursorArea').forEach(part => {
+            part.classList.remove('selected-suit-part-1', 'selected-suit-part-2', 'selected-suit-part-3');
+        });
+
+        suitEffectsCheckBoxStatusBackup.forEach((setName, index) => {
+            const setData = allEquipmentData.find(set => set.set === setName);
+            if (setData) {
+                setData.parts.forEach(part => {
+                    const equipmentPart = document.getElementById(`${part.part}-compare`);
+                    if (selectedBuildList[part.part] && selectedBuildList[part.part].setName === setName) {
+                        if (equipmentPart) {
+                            equipmentPart.classList.add(`selected-suit-part-${index + 1}`);
+                        }
+                    }
+                });
+            }
+        });
+    }
+}
+
+function setupBuild(selectedBuildList, suitEffectsCheckBoxStatus) {
+    processSelectedComparePart(selectedBuildList, true);
+
+    const suitEffectsList = document.getElementById("suitEffectsList");
     suitEffectsList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
         let isMatch = suitEffectsCheckBoxStatus.some(item => checkbox.id.startsWith(item));
         if (isMatch) {
@@ -457,31 +497,20 @@ function saveSelectedBuildData(selectedBuildList, suitEffectsCheckBoxStatus) {
     });
 }
 
+function showCompareBuildConfirmModal() {
+    processSelectedComparePart(selectedAttributesBackup, false);
+    compareBuildConfirmModal.show();
+}
+
 function processCompareBuild() {
-    if (this.classList.contains('btn-outline-primary')) {
-        this.classList.remove('btn-outline-primary');
-        this.classList.add('btn-warning');
-        this.innerHTML = "穿原本套";
-
-        // 穿上之前先記錄目前選擇的所有冰裝與套裝效果再穿上
-        saveSelectedBuildData(selectedAttributesOrigin, suitEffectsCheckBoxStatusOrigin);
-
-        // 開始穿上
-        setupBuild(selectedAttributesBackup, suitEffectsCheckBoxStatusBackup);
-    } else {
-        this.classList.remove('btn-warning');
-        this.classList.add('btn-outline-primary');
-        this.innerHTML = "穿比較套";
-
-        // 穿回的時候用穿上之前紀錄的狀態
-        setupBuild(selectedAttributesOrigin, suitEffectsCheckBoxStatusOrigin);
-    }
+    setupBuild(selectedAttributesBackup, suitEffectsCheckBoxStatusBackup);
 
     // 重新處理畫面渲染和數值計算
     updateFinalValues();
     removeZeroCountSuits();
     applySuitEffectClasses();
     updateComparisonDisplay();
+    compareBuildConfirmModal.hide();
 }
 
 function saveCurrentValues() {

--- a/style/els.css
+++ b/style/els.css
@@ -434,3 +434,7 @@ label {
   width: 100%;
   margin-bottom: 15px;
 }
+
+.normalCursorArea {
+  cursor: default;
+}


### PR DESCRIPTION
新增穿比較套按鈕功能
### 新增說明:

因為目前在搭配期間查看比較時僅顯示數值差異，並未顯示完整冰裝配置差異，導致截圖記錄或查看冰裝搭配差異時，在兩套冰裝配置之間反覆點選設定。  
加上多次搭配不同冰裝時可能會忘記先前冰裝配置內容，因而新增此功能幫助在搭配期間可以完整且快速的切換先前新增比較時候的冰裝配置內容。

### 功能介紹:

在搭配完冰裝效果後，點選新增比較按鈕時，新增一個穿比較套的按鈕，可用於快速來回切換兩套不同冰裝的配置。  
穿比較套按鈕點選後會將當前一次新增比較時，紀錄的配置完整的切換且該按鈕名稱及樣式會更改如下圖示:

點選前為(下圖一)

<img width="243" height="50" alt="image" src="https://github.com/user-attachments/assets/872f621a-b898-432b-a424-1e0bb9e96a5f" />

點選後變更為穿原本套(下圖二)

<img width="244" height="45" alt="image" src="https://github.com/user-attachments/assets/ad32ab18-eaed-4c48-b5eb-f248f16ffb85" />

再次點選會變回圖一

### 功能操作展示:

https://github.com/user-attachments/assets/0b38d01e-24c3-43b8-96d7-322ea3d9450b
